### PR TITLE
Fix a bug where matching query parameters will fail for a query string t...

### DIFF
--- a/MobileDeepLinking-Android-SDK/src/main/java/org/mobiledeeplinking/android/DeeplinkMatcher.java
+++ b/MobileDeepLinking-Android-SDK/src/main/java/org/mobiledeeplinking/android/DeeplinkMatcher.java
@@ -48,7 +48,7 @@ public class DeeplinkMatcher
         {
             return null;
         }
-        results = matchQueryParameters(routeOptions, deeplink.getQuery(), results);
+        results = matchQueryParameters(routeOptions, deeplink.getEncodedQuery(), results);
         if (results == null)
         {
             return null;


### PR DESCRIPTION
...hat has URL encoded values.

This does not happen with the iOS version of the namesake library.

Repro: mdldemo://handler/3?referrer=utm_campaign%3Dsomecampaign

MobileDeepLinkingConfig.json (added "referrer" as a routeParameter and display the value through the testHandler):

```
    "handler/:handlerId": {
        "handlers": ["testHandler"],
        "class": "com.mobiledeeplinking.android.demo.SecondActivity",
        "routeParameters" : {
            "handlerId" : {
                "regex": "[0-9]"
            },
            "referrer" : {}
        }
    }
```
